### PR TITLE
Disable metadata only records

### DIFF
--- a/ogc-application-catalog/invenio.cfg
+++ b/ogc-application-catalog/invenio.cfg
@@ -251,3 +251,6 @@ RDM_CUSTOM_FIELDS_UI = [
         ]
     }
 ]
+
+# Disable the option for metadata-only records, require that users include files in their uploads in order to publish.
+RDM_ALLOW_METADATA_ONLY_RECORDS = False


### PR DESCRIPTION
Disables allowing records to be published that do not have any files attached.