### PR TITLE
Add environment.yml to give a base development environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ register-api/storage
 **/.terraform
 register-api/build
 **/__pycache__
+**/celerybeat-schedule.*

--- a/ogc-application-catalog/Pipfile
+++ b/ogc-application-catalog/Pipfile
@@ -15,7 +15,7 @@ uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 
 [requires]
-python_version = "3.9"
+python_version = "3"
 
 [pipenv]
 allow_prereleases = false

--- a/ogc-application-catalog/environment.yml
+++ b/ogc-application-catalog/environment.yml
@@ -1,0 +1,11 @@
+name: invenio-rdm
+channels:
+- conda-forge
+dependencies:
+- python>=3.9
+- openssl<3.0.0 # >=3.0.0 causes seg faults in psycopg2 module 
+- nodejs
+- imagemagick
+- expect
+- pip:
+  - invenio-cli


### PR DESCRIPTION
Note that this environment sets openssl < 3.0.0 because I was having issues with segfaults between version >= 3.0.0 and the python psycopg2 module installed into the RDM environment.