### PR TITLE
Added file upload limitations

### DIFF
--- a/ogc-application-catalog/invenio.cfg
+++ b/ogc-application-catalog/invenio.cfg
@@ -136,6 +136,14 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
 
 APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES = 'search' # "search_only" or "off"
 
+# File upload quotas
+APP_RDM_DEPOSIT_FORM_QUOTA = {
+    "maxFiles": 1,
+    "maxStorage": 500*10**6,  # Limit file uploads to 500MB
+}
+FILES_REST_DEFAULT_QUOTA_SIZE = 500*10**6
+FILES_REST_DEFAULT_MAX_FILE_SIZE = 500*10**6
+
 # Invenio-Records-Resources
 # =========================
 # See https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/config.py


### PR DESCRIPTION
## Purpose

This PR addresses the need to limit the number of file uploads to one file. It also sets the maximum size for files and quotas to 500MB. Unfortunately, InvenioRDM only provides a way to set the individual file size limit for the rest endpoint, not for the UI. However, since we are currently only allowing one file per quota, it behaves as we intended. If we increase the number of files that can be uploaded using the UI, we will need to come up with a reasonable quota file size.
 
## Proposed Changes
- [ADD] Limit to the number of files for both the UI and Rest interface to 1 file
- [ADD] Limit the total size of file uploads to 500MB.

## Issues
- Resolves #40 

## Testing
- Tested in my local instance

#### File Upload limits displayed to the user:

<img width="1128" height="575" alt="Screenshot 2025-08-12 at 5 47 27 PM" src="https://github.com/user-attachments/assets/9f69a0fc-d7d7-43bf-86c4-b45af5e4778e" />

#### File upload limits in action:

<img width="1042" height="308" alt="image" src="https://github.com/user-attachments/assets/2c94695b-2c36-443f-bc0e-a94a160c2a81" />
