### PR TITLE
Implement a much more maintable solution for overriding the deposit form

### DIFF
--- a/ogc-application-catalog/assets/js/components/deposit_form/CustomResourceType.js
+++ b/ogc-application-catalog/assets/js/components/deposit_form/CustomResourceType.js
@@ -1,0 +1,9 @@
+import { parametrize } from 'react-overridable';
+import { ResourceTypeField } from "@js/invenio_rdm_records";
+
+// Allow form to show up, but disable modification
+// default value set inside of invenio.cfg APP_RDM_DEPOSIT_FORM_DEFAULTS setting
+export const CustomResourceTypeField = parametrize(ResourceTypeField, {
+  label: "Application Resource Type",
+  disabled: true
+});

--- a/ogc-application-catalog/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/ogc-application-catalog/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -4,115 +4,7 @@
 // Invenio App RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import _get from "lodash/get";
-import { FieldLabel, SelectField } from "react-invenio-forms";
-import { i18next } from "@translations/invenio_rdm_records/i18next";
-import { FormikContext } from "formik";
-
-/**const MDPS_CUSTOM_OPTIONS = [
-  { id: "ogcapplicationpackage",       type_name: "OGC Application Package",       subtype_name: null,        icon: "cubes" },
-  { id: "workflow",    type_name: "Workflow",    subtype_name: null,    icon: "tasks" },
-  { id: "ancillary-data",    type_name: "Ancillary data",    subtype_name: null,        icon: "table" },
-  { id: "auxiliary-data",     type_name: "Auxilliary data",     subtype_name: null,    icon: "chart line" },
-  { id: "shell-script",     type_name: "Shell-script",     subtype_name: null,    icon: "terminal" },
-  { id: "notebook",     type_name: "Notebook",     subtype_name: null,    icon: "book" },
-];**/
-
-export class ResourceTypeField extends Component {
-
-	static contextType = FormikContext
-
-  groupErrors = (errors, fieldPath) => {
-    const fieldErrors = _get(errors, fieldPath);
-    if (fieldErrors) {
-      return { content: fieldErrors };
-    }
-    return null;
-  };
-
-  /**
-   * Generate label value
-   *
-   * @param {object} option - back-end option
-   * @returns {string} label
-   */
-  _label = (option) => {
-    return option.type_name + (option.subtype_name ? " / " + option.subtype_name : "");
-  };
-
-  /**
-   * Convert back-end options to front-end options.
-   *
-   * @param {array} propsOptions - back-end options
-   * @returns {array} front-end options
-   */
-  createOptions = (propsOptions) => {
-    return propsOptions
-      .map((o) => ({ ...o, label: this._label(o) }))
-      .sort((o1, o2) => o1.label.localeCompare(o2.label))
-      .map((o) => {
-        return {
-          value: o.id,
-          icon: o.icon,
-          text: o.label,
-        };
-      });
-  };
-
-  componentDidMount() {
-    const { values, setFieldValue } = this.context;
-    const { fieldPath } = this.props;
-    // only seed once if nothing’s already selected
-    if (!values[fieldPath]) {
-      setFieldValue(fieldPath, "ogc-application-package");
-    }
-  }
-
-  render() {
-    const { fieldPath, label, labelIcon, options, ...restProps } = this.props;
-    const frontEndOptions = this.createOptions(options);
-    return (
-    	<div style={{ display: "none" }}>
-	      <SelectField
-	        fieldPath={fieldPath}
-	        label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
-	        optimized
-	        aria-label={label}
-	        options={frontEndOptions}
-	        selectOnBlur={false}
-	        {...restProps}
-	      />
-      	</div>
-    );
-  }
-}
-
-ResourceTypeField.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string,
-  labelIcon: PropTypes.string,
-  labelclassname: PropTypes.string,
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      icon: PropTypes.string,
-      type_name: PropTypes.string,
-      subtype_name: PropTypes.string,
-      id: PropTypes.string,
-    })
-  ).isRequired,
-  required: PropTypes.bool,
-};
-
-ResourceTypeField.defaultProps = {
-  label: i18next.t("Resource types"),
-  labelIcon: "tag",
-  labelclassname: "field-label-class",
-  required: false,
-};
-
-export default ResourceTypeField;
+import { CustomResourceTypeField } from "../../components/deposit_form/CustomResourceType";
 
 export const overriddenComponents = {
 	"InvenioAppRdm.Deposit.AccordionFieldFunding.container": ()=> null,
@@ -123,5 +15,5 @@ export const overriddenComponents = {
 	"InvenioAppRdm.Deposit.RelatedWorksField.container": ()=> null,
 	"InvenioAppRdm.Deposit.AccordionFieldReferences.container": ()=> null,
 	"InvenioAppRdm.Deposit.ReferencesField.container": ()=> null,
-	"InvenioAppRdm.Deposit.ResourceTypeField.container": ResourceTypeField,
+	"InvenioAppRdm.Deposit.ResourceTypeField.container": CustomResourceTypeField,
 };

--- a/ogc-application-catalog/invenio.cfg
+++ b/ogc-application-catalog/invenio.cfg
@@ -119,6 +119,7 @@ APP_RDM_ADMIN_EMAIL_RECIPIENT = "info@ogc-application-catalog.com"
 
 # Default values for the deposit form
 APP_RDM_DEPOSIT_FORM_DEFAULTS = {
+    "resource_type": "ogc-application-catalog",
     "publication_date": lambda: datetime.now().strftime("%Y-%m-%d"),
     "rights": [
         {


### PR DESCRIPTION
Implement a much more maintable solution for overriding the deposit form resource type field. Instead of duplicating code that is likely to get update, use the features of react-overridable to modify the field. Also use invenio.cfg for the default value instead of changing via a React call back.